### PR TITLE
Implement feature to select and 'redo' members

### DIFF
--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -12,7 +12,7 @@ body {
 
 body {
   font-family: 'Krona One', Arial, sans-serif;
-  font-size: 14px;'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 14px;
   line-height: 1.4em;
   font-weight: 300;
 }

--- a/src/main/scala/App.scala
+++ b/src/main/scala/App.scala
@@ -57,6 +57,20 @@ object App {
       }
     }
 
+    // TODO: refactor imperative implementation the reactive way
+    def nominateSpecificMember(member: TeamMember): Unit = {
+      if (membersTodo.now.contains(member)) {
+        memberInSpotlight.now.map((last => membersDone.set((membersDone.now: List[TeamMember]) :+ last)))
+        memberInSpotlight.set(Some(member))
+        println(s"Es freue sich: ${member.name}")
+        membersTodo.set(membersTodo.now.filter(_ != member))
+      } else if (membersDone.now.contains(member)) {
+        memberInSpotlight.now.map((last => membersTodo.set((membersTodo.now: List[TeamMember]) :+ last)))
+        memberInSpotlight.set(Some(member))
+        println(s"Es freue sich: ${member.name}")
+        membersDone.set(membersDone.now.filter(_ != member))
+      }
+    }
 
     // RENDERING
 
@@ -64,10 +78,11 @@ object App {
       span(
         className("team-member"),
         span(className("member-icon", "material-icons"), "person"),
-        member.name
+        member.name,
+        onClick --> { _ => nominateSpecificMember(member) }
       )
 
-    def renderMemberList(members: List[TeamMember])  =
+    def renderMemberList(members: List[TeamMember]) =
       ul(
         className("team-members"),
         members.map { member =>


### PR DESCRIPTION
We do have the case quite often, that we want to let a team member go first (if they have to attend another meeting, etc.). With this PR this can be done by clicking on that team members name instead of the 'spotlight'.
A second case that we had sometimes is that a team member was accidentally taken out of the 'spotlight'. With this PR that team member can be put from the 'Done'-list back into the spotlight by clicking on their name. The member currently in the 'spotlight' will be put back in the 'ToDo'-list.

There was also some broken CSS that I removed.

Feel free to adapt/fit the PR to your preferred style :wink: 

Side note: please add a `.scalafmt.conf` file. I had to disable `ale_fix_on_save` to not change unrelated lines :sweat_smile: 