### PR TITLE
Some CSS cleanup

### DIFF
--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -38,7 +38,7 @@ h1 {
 }
 .spotlight .team-member,
 .spotlight .team-member > .member-icon {
-  font-size: 40px;
+  font-size: 2.5em;
 }
 .team-members-container {
   margin-left: 50px;
@@ -54,11 +54,10 @@ h1 {
 .team-members-container > span {
   font-size: 1.5em;
 }
-.team-members {
+.team-members > ul {
   list-style: none;
   white-space: nowrap;
   line-height: 2em;
-  font-size: 120%;
 }
 .team-members > li {
   display: inline;
@@ -68,4 +67,7 @@ h1 {
   position: relative;
   top: 4px;
   margin-right: 5px;
+}
+.team-members {
+  font-size: 1.3em;
 }

--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -63,11 +63,17 @@ h1 {
   display: inline;
   margin-right: 2em;
 }
-.member-icon {
-  position: relative;
-  top: 4px;
-  margin-right: 5px;
+.team-member {
+  display: inline-flex;
+  align-items: center;
 }
-.team-members {
+.team-member:before {
+  font-family: 'Material Icons';
+  content: 'person';
+  vertical-align: middle;
+  margin-right: .1em;
+}
+.team-members,
+.team-member:before {
   font-size: 1.3em;
 }

--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -25,25 +25,21 @@ h1 {
   padding: 20px;
 }
 .spotlight {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 300px;
   height: 300px;
   border-radius: 50%;
   margin-left: 300px;
 }
-.spotlight .team-member {
-  position: relative;
-  top: 128px;
-  left: 110px;
-}
 .spotlight, .team-member {
   cursor: pointer;
 }
-/* TODO: fix this for member-icon
 .spotlight .team-member,
-.spotlight .team-member > member-icon {
-  font-size: 40px
+.spotlight .team-member > .member-icon {
+  font-size: 40px;
 }
-*/
 .team-members-container {
   margin-left: 50px;
 }

--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -12,7 +12,7 @@ body {
 
 body {
   font-family: 'Krona One', Arial, sans-serif;
-  font-size: 14px;'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 14px;
   line-height: 1.4em;
   font-weight: 300;
 }

--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -35,6 +35,9 @@ h1 {
   top: 128px;
   left: 110px;
 }
+.spotlight, .team-member {
+  cursor: pointer;
+}
 /* TODO: fix this for member-icon
 .spotlight .team-member,
 .spotlight .team-member > member-icon {

--- a/src/main/scala/App.scala
+++ b/src/main/scala/App.scala
@@ -63,7 +63,6 @@ object App {
     def renderMember(member: TeamMember): Span =
       span(
         className("team-member"),
-        span(className("member-icon", "material-icons"), "person"),
         member.name
       )
 


### PR DESCRIPTION
Just noticed that 56daebdadfabf4e8bd607cbef543647aaf186c47 is blocked by #2 as it will also highlight the members in 'Done' and 'ToDo' as clickable.